### PR TITLE
Converted regex_extract_ipv4 to python 3.6

### DIFF
--- a/custom_functions/regex_extract_ipv4.json
+++ b/custom_functions/regex_extract_ipv4.json
@@ -1,0 +1,28 @@
+{
+    "create_time": "2021-02-04T20:14:45.583664+00:00",
+    "custom_function_id": "6fb19da4a10369f21bdb015928bd3190b1f9e575",
+    "description": "Takes a single input and extracts all IPv4 addresses from it using regex.",
+    "draft_mode": false,
+    "inputs": [
+        {
+            "contains_type": [
+                "*"
+            ],
+            "description": "An input string that may contain an arbitrary number of ipv4 addresses",
+            "input_type": "list",
+            "name": "input_string",
+            "placeholder": "192.0.2.1"
+        }
+    ],
+    "outputs": [
+        {
+            "contains_type": [
+                "*"
+            ],
+            "data_path": "*.ipv4",
+            "description": "Extracted ipv4 address"
+        }
+    ],
+    "platform_version": "4.10.0.40961",
+    "python_version": "3"
+}

--- a/custom_functions/regex_extract_ipv4.py
+++ b/custom_functions/regex_extract_ipv4.py
@@ -1,0 +1,31 @@
+def regex_extract_ipv4(input_string=None, **kwargs):
+    """
+    Takes a single input and extracts all IPv4 addresses from it using regex.
+    
+    Args:
+        input_string (CEF type: *): An input string that may contain an arbitrary number of ipv4 addresses
+    
+    Returns a JSON-serializable object that implements the configured data paths:
+        *.ipv4 (CEF type: *): Extracted ipv4 address
+    """
+    ############################ Custom Code Goes Below This Line #################################
+    import json
+    import phantom.rules as phantom
+    import re
+    
+    outputs = []
+    ip_list = []
+    for ip in input_string:
+        if ip:
+            ip_rex = re.findall('(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)',ip)
+            for ip in set(ip_rex):
+                ip_list.append(ip)
+                
+    for ip in set(ip_list):
+        outputs.append({"ipv4": ip})
+            
+    phantom.debug("Extracted ips: {}".format(outputs))
+    
+    # Return a JSON-serializable object
+    assert json.dumps(outputs)  # Will raise an exception if the :outputs: object is not JSON-serializable
+    return outputs


### PR DESCRIPTION
Converted regex_extract_ipv4 to python 3.6. Confirmed working on phantom 4.10 running in playbook version 3.6.
Input Text from format block:
> abcd efgh 5.9.10.7
> abde fhgh
> erh192.168.10.75waer234
> ermygard999.995.43.21

Output: `Extracted ips: [{'ipv4': '192.168.10.75'}, {'ipv4': '5.9.10.7'}]`

![Screen Shot 2021-02-04 at 2 22 14 PM](https://user-images.githubusercontent.com/69353980/106950737-71aabb80-66f4-11eb-89e0-87178d76addb.png)