### PR TITLE
Bug fix for indicator_get_by_tag

### DIFF
--- a/custom_functions/indicator_get_by_tag.json
+++ b/custom_functions/indicator_get_by_tag.json
@@ -1,6 +1,6 @@
 {
-    "create_time": "2021-08-27T14:42:51.824426+00:00",
-    "custom_function_id": "7e304fa9f4afcb82df42669646baa18fb0afb890",
+    "create_time": "2021-09-07T22:22:07.283261+00:00",
+    "custom_function_id": "cbcb2ba4c8d06c363d7fe280ef8a07b92bd8c6ab",
     "description": "Get indicator(s) by tags.",
     "draft_mode": false,
     "inputs": [


### PR DESCRIPTION
Adjusted custom function to iterate through the current container artifacts via collect2 call rather than common_container rest call. It was observed that if an indicator was deleted from a container it will still be present in the database of common containers but not actually be present in that container.