### PR TITLE
Enhancement to Find Related Containers

### DIFF
--- a/custom_functions/find_related_containers.json
+++ b/custom_functions/find_related_containers.json
@@ -1,5 +1,5 @@
 {
-    "create_time": "2022-03-28T20:35:37.492740+00:00",
+    "create_time": "2022-03-29T14:18:25.856740+00:00",
     "custom_function_id": "5781e3d5a4773b2c48afd429768fd81b5e733e54",
     "description": "Takes a provided list of indicator values to search for and finds all related containers. It will produce a list of the related container details.",
     "draft_mode": false,

--- a/custom_functions/find_related_containers.json
+++ b/custom_functions/find_related_containers.json
@@ -1,5 +1,5 @@
 {
-    "create_time": "2022-03-18T17:08:29.341909+00:00",
+    "create_time": "2022-03-18T17:22:30.114748+00:00",
     "custom_function_id": "5781e3d5a4773b2c48afd429768fd81b5e733e54",
     "description": "Takes a provided list of indicator values to search for and finds all related containers. It will produce a list of the related container details.",
     "draft_mode": false,
@@ -17,7 +17,7 @@
             "contains_type": [
                 "*"
             ],
-            "description": "The minimum number of values from the value_list parameter that must match with related containers. Supports an integer or the string 'all'. Adding 'all' will set the minimum_match_count to the length of the provided value_list. If no match count provided, this will default to 1.",
+            "description": "The minimum number of values from the value_list parameter that must match with related containers. Supports an integer or the string 'all'. Adding 'all' will set the minimum_match_count to the length of the number of unique values in the value_list. If no match count provided, this will default to 1.",
             "input_type": "item",
             "name": "minimum_match_count",
             "placeholder": "1-100"

--- a/custom_functions/find_related_containers.json
+++ b/custom_functions/find_related_containers.json
@@ -1,5 +1,5 @@
 {
-    "create_time": "2022-03-25T16:50:20.986569+00:00",
+    "create_time": "2022-03-28T20:35:37.492740+00:00",
     "custom_function_id": "5781e3d5a4773b2c48afd429768fd81b5e733e54",
     "description": "Takes a provided list of indicator values to search for and finds all related containers. It will produce a list of the related container details.",
     "draft_mode": false,

--- a/custom_functions/find_related_containers.json
+++ b/custom_functions/find_related_containers.json
@@ -1,5 +1,5 @@
 {
-    "create_time": "2022-03-23T14:47:11.920219+00:00",
+    "create_time": "2022-03-24T16:19:55.968997+00:00",
     "custom_function_id": "5781e3d5a4773b2c48afd429768fd81b5e733e54",
     "description": "Takes a provided list of indicator values to search for and finds all related containers. It will produce a list of the related container details.",
     "draft_mode": false,

--- a/custom_functions/find_related_containers.json
+++ b/custom_functions/find_related_containers.json
@@ -1,5 +1,5 @@
 {
-    "create_time": "2022-03-18T17:22:30.114748+00:00",
+    "create_time": "2022-03-23T14:47:11.920219+00:00",
     "custom_function_id": "5781e3d5a4773b2c48afd429768fd81b5e733e54",
     "description": "Takes a provided list of indicator values to search for and finds all related containers. It will produce a list of the related container details.",
     "draft_mode": false,

--- a/custom_functions/find_related_containers.json
+++ b/custom_functions/find_related_containers.json
@@ -1,5 +1,5 @@
 {
-    "create_time": "2022-02-10T18:24:50.244936+00:00",
+    "create_time": "2022-03-18T17:08:29.341909+00:00",
     "custom_function_id": "5781e3d5a4773b2c48afd429768fd81b5e733e54",
     "description": "Takes a provided list of indicator values to search for and finds all related containers. It will produce a list of the related container details.",
     "draft_mode": false,
@@ -17,7 +17,7 @@
             "contains_type": [
                 "*"
             ],
-            "description": "The minimum number of similar indicator records that a container must have to be considered \"related.\"  If no match count provided, this will default to 1.",
+            "description": "The minimum number of values from the value_list parameter that must match with related containers. Supports an integer or the string 'all'. Adding 'all' will set the minimum_match_count to the length of the provided value_list. If no match count provided, this will default to 1.",
             "input_type": "item",
             "name": "minimum_match_count",
             "placeholder": "1-100"
@@ -41,27 +41,27 @@
         {
             "contains_type": [],
             "description": "Optional comma-separated list of statuses to filter on. Only containers that have statuses matching an item in this list will be included.",
-            "input_type": "item",
+            "input_type": "list",
             "name": "filter_status",
             "placeholder": "open"
         },
         {
             "contains_type": [],
             "description": "Optional comma-separated list of labels to filter on. Only containers that have labels matching an item in this list will be included.",
-            "input_type": "item",
+            "input_type": "list",
             "name": "filter_label",
             "placeholder": "events"
         },
         {
             "contains_type": [],
             "description": "Optional comma-separated list of severities to filter on. Only containers that have severities matching an item in this list will be included.",
-            "input_type": "item",
+            "input_type": "list",
             "name": "filter_severity",
             "placeholder": "medium"
         },
         {
             "contains_type": [],
-            "description": "Optional parameter to filter containers that are in a case or not. Defaults to True (drop containers that are already in a case).",
+            "description": "Optional parameter to filter containers that are in a case or not.",
             "input_type": "item",
             "name": "filter_in_case",
             "placeholder": "True or False"

--- a/custom_functions/find_related_containers.json
+++ b/custom_functions/find_related_containers.json
@@ -1,5 +1,5 @@
 {
-    "create_time": "2022-03-24T16:19:55.968997+00:00",
+    "create_time": "2022-03-25T16:50:20.986569+00:00",
     "custom_function_id": "5781e3d5a4773b2c48afd429768fd81b5e733e54",
     "description": "Takes a provided list of indicator values to search for and finds all related containers. It will produce a list of the related container details.",
     "draft_mode": false,

--- a/custom_functions/find_related_containers.py
+++ b/custom_functions/find_related_containers.py
@@ -4,7 +4,7 @@ def find_related_containers(value_list=None, minimum_match_count=None, container
     
     Args:
         value_list (CEF type: *): An indicator value to search on, such as a file hash or IP address. To search on all indicator values in the container, use "*".
-        minimum_match_count (CEF type: *): The minimum number of values from the value_list parameter that must match with related containers. Supports an integer or the string 'all'. Adding 'all' will set the minimum_match_count to the length of the provided value_list. If no match count provided, this will default to 1.
+        minimum_match_count (CEF type: *): The minimum number of values from the value_list parameter that must match with related containers. Supports an integer or the string 'all'. Adding 'all' will set the minimum_match_count to the length of the number of unique values in the value_list. If no match count provided, this will default to 1.
         container (CEF type: phantom container id): The container to run indicator analysis against. Supports container object or container_id. This container will also be excluded from the results for related_containers.
         earliest_time: Optional modifier to only consider related containers within a time window. Default is -30d.  Supports year (y), month (m), day (d), hour (h), or minute (m)  Custom function will always set the earliest container window based on the input container "create_time".
         filter_status: Optional comma-separated list of statuses to filter on. Only containers that have statuses matching an item in this list will be included.
@@ -228,7 +228,7 @@ def find_related_containers(value_list=None, minimum_match_count=None, container
             filter_in_case=filter_in_case
         )
     else:
-        phantom.debug(f"No related containers found found for provided values: '{value_list}'")
+        phantom.debug(f"No related containers found for '{minimum_match_count}' minimum matches out of the provided values: '{value_list}'")
         
     # Return a JSON-serializable object
     assert json.dumps(outputs)  # Will raise an exception if the :outputs: object is not JSON-serializable

--- a/custom_functions/find_related_containers.py
+++ b/custom_functions/find_related_containers.py
@@ -184,7 +184,7 @@ def find_related_containers(value_list=None, minimum_match_count=None, container
             if isinstance(item, str) or isinstance(item, bool) or isinstance(item, int) or isinstance(item, float):
                 value_set.add(str(item))
         value_list = list(value_set)
-    elif isinstance(item, str) or isinstance(item, bool) or isinstance(item, int) or isinstance(item, float):
+    elif isinstance(value_list, str) or isinstance(value_list, bool) or isinstance(value_list, int) or isinstance(value_list, float):
         value_list = [str(value_list)]
     else:
         raise TypeError(f"Invalid input for value_list: '{value_list}'")

--- a/custom_functions/find_related_containers.py
+++ b/custom_functions/find_related_containers.py
@@ -70,8 +70,7 @@ def find_related_containers(value_list=None, minimum_match_count=None, container
                 if k == 'filter_severity':
                     container_url += f'&_filter_severity__in={v}'
                 if k == 'filter_in_case':
-                    container_url += f'&_filter_in_case="{str(v).lower()}"'
-                    
+                    container_url += f'&_filter_in_case="{str(v).lower()}"'              
                     
         container_id_list = list(container_dict.keys())
         for group in grouper(container_id_list, 100):
@@ -209,8 +208,7 @@ def find_related_containers(value_list=None, minimum_match_count=None, container
         filter_in_case = False
     
     ## ------------------- ##
-    ## End Endput Checking ##
-
+    ## End Input Checking ##
 
     indicator_dictionary, indicator_id_set = fetch_indicators(value_list)
 

--- a/custom_functions/find_related_containers.py
+++ b/custom_functions/find_related_containers.py
@@ -70,7 +70,7 @@ def find_related_containers(value_list=None, minimum_match_count=None, container
                 if k == 'filter_severity':
                     container_url += f'&_filter_severity__in={v}'
                 if k == 'filter_in_case':
-                    container_url += f'&_filter_in_case="{v.lower()}"'
+                    container_url += f'&_filter_in_case="{str(v).lower()}"'
                     
                     
         container_id_list = list(container_dict.keys())

--- a/custom_functions/find_related_containers.py
+++ b/custom_functions/find_related_containers.py
@@ -171,13 +171,17 @@ def find_related_containers(value_list=None, minimum_match_count=None, container
         response_data = phantom.requests.get(uri=url, verify=False).json()
         for data in response_data.get('data', []):
             for k,v in data['cef'].items():
-                new_value_list.add(str(v))
+                if isinstance(v, str) or isinstance(v, bool) or isinstance(v, int) or isinstance(v, float):
+                     new_value_list.add(str(v))
         value_list = list(new_value_list)
     elif isinstance(value_list, list):
-        # dedup value_list
-        value_list = list(set(value_list))
-    elif isinstance(value_list, str):
-        value_list = [value_list]
+        value_set = set()
+        for item in value_list:
+            if isinstance(item, str) or isinstance(item, bool) or isinstance(item, int) or isinstance(item, float):
+                value_set.add(str(item))
+        value_list = list(value_set)
+    elif isinstance(item, str) or isinstance(item, bool) or isinstance(item, int) or isinstance(item, float):
+        value_list = [str(value_list)]
     else:
         raise TypeError(f"Invalid input for value_list: '{value_list}'")
     


### PR DESCRIPTION
## Rewrote minimum_match_count
- minimum_match_count now checks to ensure that the number of related indicators in a container contain at least `n` number of values provided in the value_list parameter.
- Added 'all' parameter which dynamically sets minimum_match_count to the size of value_list

## Rewrote indicator value to ID translation
- Now uses the sha256 value_hash of the value and the _in operator to filter against the indicator table

## Rewrote container detail collection
- Now always queries the entire container table with the user provided filtering and the in operator.
- Should now be performant regardless of number of containers that are related

## Overall documentation improvements
- Moved multiple portions of code to function calls