### PR TITLE
Update datetime_modify.py to use utcnow

### DIFF
--- a/custom_functions/datetime_modify.py
+++ b/custom_functions/datetime_modify.py
@@ -27,7 +27,7 @@ def datetime_modify(input_datetime=None, input_format_string=None, modification_
     
     # set the date to the default, which is the current time if none is provided
     if not input_datetime:
-        input_datetime = datetime.datetime.now().strftime(input_format_string)
+        input_datetime = datetime.datetime.utcnow().strftime(input_format_string)
     
     # use the phantom default as the output format string if none is provided
     if not output_format_string:


### PR DESCRIPTION
Update datetime_modify.py to use utcnow if the user doesn't provide a value for input_datetime. The current logic doesn't work if the system timezone has been modified from UTC.

Currently, if input_datetime and input_format_string aren't provided, this function uses now() to get the local time and a UTC strftime format to record that local time with a UTC 'Z' timezone value. The only way to use datetime_modify to get the current time - or do maths against it - is if you provided an input_format_string with the time offset specified, which isn't practical when you have to factor in DST.