### PR TITLE
Overhauled regex_extract_ipv4 to support new use cases

### DIFF
--- a/custom_functions/regex_extract_ipv4.json
+++ b/custom_functions/regex_extract_ipv4.json
@@ -1,6 +1,6 @@
 {
-    "create_time": "2021-03-23T19:52:27.702665+00:00",
-    "custom_function_id": "031e0d2e7d63647b12b99750a49038e9df5a0f3c",
+    "create_time": "2023-03-01T22:02:03.385755+00:00",
+    "custom_function_id": "35b8f221e2aea777070ef3c59e1397bab87eef82",
     "description": "Takes a single input and extracts all IPv4 addresses from it using regex.",
     "draft_mode": false,
     "inputs": [
@@ -9,7 +9,7 @@
                 "*"
             ],
             "description": "An input string that may contain an arbitrary number of ipv4 addresses",
-            "input_type": "list",
+            "input_type": "item",
             "name": "input_string",
             "placeholder": "192.0.2.1"
         }
@@ -19,10 +19,16 @@
             "contains_type": [
                 "ip"
             ],
-            "data_path": "*.ipv4",
-            "description": "Extracted ipv4 address"
+            "data_path": "extracted_ipv4",
+            "description": "Extracted ipv4 address. Will be none if no IP was extracted."
+        },
+        {
+            "contains_type": [],
+            "data_path": "input_value",
+            "description": "The value that was used as input to produce the extracted IP."
         }
     ],
-    "platform_version": "4.10.0.40961",
+    "outputs_type": "list",
+    "platform_version": "6.0.0.114895",
     "python_version": "3"
 }

--- a/custom_functions/regex_extract_ipv4.py
+++ b/custom_functions/regex_extract_ipv4.py
@@ -6,7 +6,8 @@ def regex_extract_ipv4(input_string=None, **kwargs):
         input_string (CEF type: *): An input string that may contain an arbitrary number of ipv4 addresses
     
     Returns a JSON-serializable object that implements the configured data paths:
-        *.ipv4 (CEF type: ip): Extracted ipv4 address
+        extracted_ipv4 (CEF type: ip): Extracted ipv4 address. Will be none if no IP was extracted.
+        input_value: The value that was used as input to produce the extracted IP.
     """
     ############################ Custom Code Goes Below This Line #################################
     import json
@@ -15,17 +16,19 @@ def regex_extract_ipv4(input_string=None, **kwargs):
     
     outputs = []
     ip_list = []
-    for ip in input_string:
-        if ip:
-            ip_rex = re.findall('(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)',ip)
-            for ip in set(ip_rex):
-                ip_list.append(ip)
-                
-    for ip in set(ip_list):
-        outputs.append({"ipv4": ip})
-            
+    if input_string:
+        ip_rex = re.findall('(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)', input_string)
+        for ip in set(ip_rex):
+            ip_list.append(ip)
+    if ip_list:
+        for ip in set(ip_list):
+            outputs.append({"extracted_ipv4": ip, "input_value": input_string})
+    else:
+        outputs.append({"extracted_ipv4": None, "input_value": input_string})
+
     phantom.debug("Extracted ips: {}".format(outputs))
     
     # Return a JSON-serializable object
+    assert isinstance(outputs, list)  # Will raise an exception if the :outputs: object is not a list
     assert json.dumps(outputs)  # Will raise an exception if the :outputs: object is not JSON-serializable
     return outputs


### PR DESCRIPTION
1. Switched extract IP to an item style input, allowing it to iterate through multiple inputs.
2. Switched outputs to a list style, allowing it to produce one-to-many results if the input string had multiple embedded IPs
3. Added the input_value to the outputs to allow filtering on values that didn't have an IP