### PR TITLE
#161 Fixing an error in indicator_collect custom function

### DIFF
--- a/custom_functions/indicator_collect.json
+++ b/custom_functions/indicator_collect.json
@@ -25,28 +25,28 @@
         {
             "contains_type": [],
             "description": "Optional parameter to only include indicators with at least one of the provided types in the output. If left empty, all indicator types will be included except those that are explicitly excluded. Accepts a comma-separated list.",
-            "input_type": "list",
+            "input_type": "item",
             "name": "indicator_types_include",
             "placeholder": "ip, domain"
         },
         {
             "contains_type": [],
             "description": "Optional parameter to exclude indicators with any of the provided types from the output. Accepts a comma-separated list.",
-            "input_type": "list",
+            "input_type": "item",
             "name": "indicator_types_exclude",
             "placeholder": "ip, domain"
         },
         {
             "contains_type": [],
             "description": "Optional parameter to only include indicators with at least one of the provided tags in the output. If left empty, tags will be ignored except when they are excluded. Accepts a comma-separated list.",
-            "input_type": "list",
+            "input_type": "item",
             "name": "indicator_tags_include",
             "placeholder": "not_contained, malware"
         },
         {
             "contains_type": [],
             "description": "Optional parameter to exclude indicators with any of the provided tags from the output. Accepts a comma-separated list.",
-            "input_type": "list",
+            "input_type": "item",
             "name": "indicator_tags_exclude",
             "placeholder": "contained, not_malware"
         }


### PR DESCRIPTION
The error in the `indicator_collect` custom function should have been fixed by changing the input types of `indicator_types` and `indicator_tags` from a Python list to a single item. Thus, the function will receive a comma-separated list as a string argument, which it will later convert into a Python list.