### PR TITLE
Fixed error when task is blank

### DIFF
--- a/custom_functions/workbook_task_update.json
+++ b/custom_functions/workbook_task_update.json
@@ -1,6 +1,6 @@
 {
-    "create_time": "2023-01-03T18:43:08.153116+00:00",
-    "custom_function_id": "4f38e1e5eb505450e4113fb5ed9a992f2c0a08cf",
+    "create_time": "2024-10-22T13:56:53.177332+00:00",
+    "custom_function_id": "604940fa449e181fe3d684c445cfe218932a33b1",
     "description": "Update a workbook task by task name or the task where the currently running playbook appears. Requires a task_name, container_id, and a note_title, note_content, owner, or status.",
     "draft_mode": false,
     "inputs": [
@@ -67,6 +67,6 @@
         }
     ],
     "outputs_type": "item",
-    "platform_version": "5.5.0.108488",
+    "platform_version": "6.3.0.709",
     "python_version": "3"
 }

--- a/custom_functions/workbook_task_update.py
+++ b/custom_functions/workbook_task_update.py
@@ -40,25 +40,27 @@ def workbook_task_update(task_name=None, note_title=None, note_content=None, sta
             current_playbook = (phantom.get_playbook_info()[0]['repo_name'], phantom.get_playbook_info()[0]['name'])
             
         for task in task_list:
-            match = False
-            if task_name == 'playbook':
-                playbooks = task['data']['suggestions'].get('playbooks', [])
-                for playbook in playbooks:
-                    if playbook['scm'] == current_playbook[0] and playbook['playbook'] == current_playbook[1]:
-                        match = True
-                        task_count += 1
-            elif task_name == task['data']['name']:
-                match = True
-                task_count += 1
-                
-            if match == True:
-                task_id = task['data']['id']
-                task_is_note_required = task['data']['is_note_required']
-                task_status = task['data']['status']
-                task_notes = task['data']['notes']
-                task_owner = task['data']['owner']
-                if task_is_note_required and status == 'complete' and task_status != 1:
-                    closing_note = True
+            if task['success'] and task.get('data'):
+                task_data = task['data']
+                match = False
+                if task_name == 'playbook':
+                    playbooks = task_data['suggestions'].get('playbooks', [])
+                    for playbook in playbooks:
+                        if playbook['scm'] == current_playbook[0] and playbook['playbook'] == current_playbook[1]:
+                            match = True
+                            task_count += 1
+                elif task_name == task_data['name']:
+                    match = True
+                    task_count += 1
+
+                if match == True:
+                    task_id = task_data['id']
+                    task_is_note_required = task_data['is_note_required']
+                    task_status = task_data['status']
+                    task_notes = task_data['notes']
+                    task_owner = task_data['owner']
+                    if task_is_note_required and status == 'complete' and task_status != 1:
+                        closing_note = True
                 
     elif not task_name:
         raise RuntimeError("Missing input for task_name.")


### PR DESCRIPTION
In some situations, a task cannot be successfully retrieved. The custom function attempted to access the data of this task, producing an error.

This update:
- Checks to see if the task was obtained successfully and has data
- Stylistic cleanup to use task_data instead of task['data'] in multiple locations