### PR TITLE
Migrate custom functions to Python 3.13

### DIFF
--- a/custom_functions/artifact_create.json
+++ b/custom_functions/artifact_create.json
@@ -1,6 +1,6 @@
 {
-    "create_time": "2025-08-22T15:13:10.641510+00:00",
-    "custom_function_id": "b705f07c883eae033c60aebe4779bd4eba61121d",
+    "create_time": "2026-03-12T01:52:29.767919+00:00",
+    "custom_function_id": "f23ade900d391687cd80d2b212b082d43b99166a",
     "description": "Create a new artifact with the specified attributes. Supports all fields available in /rest/artifact. Add any unlisted inputs as dictionary keys in input_json. Unsupported keys will automatically be dropped.",
     "draft_mode": false,
     "inputs": [
@@ -91,6 +91,6 @@
         }
     ],
     "outputs_type": "item",
-    "platform_version": "6.4.1.361",
-    "python_version": "3.9"
+    "platform_version": "8.4.0.158",
+    "python_version": "3.13"
 }

--- a/custom_functions/artifact_create.json
+++ b/custom_functions/artifact_create.json
@@ -1,6 +1,6 @@
 {
     "create_time": "2026-03-12T01:52:29.767919+00:00",
-    "custom_function_id": "f23ade900d391687cd80d2b212b082d43b99166a",
+    "custom_function_id": "b705f07c883eae033c60aebe4779bd4eba61121d",
     "description": "Create a new artifact with the specified attributes. Supports all fields available in /rest/artifact. Add any unlisted inputs as dictionary keys in input_json. Unsupported keys will automatically be dropped.",
     "draft_mode": false,
     "inputs": [

--- a/custom_functions/vault_copy_or_move.json
+++ b/custom_functions/vault_copy_or_move.json
@@ -1,6 +1,6 @@
 {
     "create_time": "2026-03-12T01:50:31.081342+00:00",
-    "custom_function_id": "752185c96dbd00f247e859fc1dc3e39265e0cf19",
+    "custom_function_id": "bc914dc7d730d32ccf6aa414b0f10f2379b9f421",
     "description": "Copies or moves one vault item from one container to another",
     "draft_mode": false,
     "inputs": [

--- a/custom_functions/vault_copy_or_move.json
+++ b/custom_functions/vault_copy_or_move.json
@@ -1,6 +1,6 @@
 {
-    "create_time": "2024-07-09T20:57:03.567249+00:00",
-    "custom_function_id": "bc914dc7d730d32ccf6aa414b0f10f2379b9f421",
+    "create_time": "2026-03-12T01:50:31.081342+00:00",
+    "custom_function_id": "752185c96dbd00f247e859fc1dc3e39265e0cf19",
     "description": "Copies or moves one vault item from one container to another",
     "draft_mode": false,
     "inputs": [
@@ -52,6 +52,6 @@
         }
     ],
     "outputs_type": "list",
-    "platform_version": "6.2.2.134",
-    "python_version": "3"
+    "platform_version": "8.4.0.158",
+    "python_version": "3.13"
 }


### PR DESCRIPTION
Modified the artifact_create and vault_copy_or_move custom functions to make them Python 3.13 compatible.