### PR TITLE
Add dual_signal_containment_gate custom function

### DIFF
--- a/custom_functions/dual_signal_containment_gate.json
+++ b/custom_functions/dual_signal_containment_gate.json
@@ -1,0 +1,68 @@
+{
+    "create_time": "2026-08-16T00:00:00.000000+00:00",
+    "custom_function_id": "6c8f3e1a9b0d47c2a5e84f1b2d6c90ae7f31b4c8",
+    "description": "Gate/Prove before block ip: deny auto-contain when the event is ML-only (SnortML GID 411, is_ml_only, or EVE-high without a classic signature). Machine-learning confidence is not a signature true positive. Signature and signature+ML corroborated paths may contain. Unknown context fails closed.",
+    "draft_mode": false,
+    "inputs": [
+        {
+            "contains_type": [
+                "*"
+            ],
+            "description": "Incident or notable title, description, and related text used to detect ML-only vs signature vs corroboration markers.",
+            "input_type": "item",
+            "name": "context",
+            "placeholder": "container.name + container.description"
+        },
+        {
+            "contains_type": [],
+            "description": "Snort / Cisco Secure Firewall GeneratorID. 411 is SnortML (ML-only). Other GIDs are classic / preprocessor signatures.",
+            "input_type": "item",
+            "name": "generator_id",
+            "placeholder": "411"
+        },
+        {
+            "contains_type": [],
+            "description": "Classic Snort classification (e.g. attempted-admin, trojan-activity).",
+            "input_type": "item",
+            "name": "classification",
+            "placeholder": "attempted-admin"
+        },
+        {
+            "contains_type": [],
+            "description": "Encrypted Visibility Engine threat confidence percent (0-100). >=80 without a classic signature is treated as ML-only.",
+            "input_type": "item",
+            "name": "eve_threat_confidence",
+            "placeholder": "80"
+        }
+    ],
+    "outputs": [
+        {
+            "contains_type": [],
+            "data_path": "disposition",
+            "description": "One of 'ml_only', 'signature', 'corroborated', or 'unknown'."
+        },
+        {
+            "contains_type": [],
+            "data_path": "allow_auto_contain",
+            "description": "'true' if block ip / auto-contain is allowed; 'false' to deny (filter before block ip)."
+        },
+        {
+            "contains_type": [],
+            "data_path": "require_hitl",
+            "description": "'true' when an analyst prompt is required (ml_only and unknown)."
+        },
+        {
+            "contains_type": [],
+            "data_path": "reason",
+            "description": "Why auto-contain was allowed or denied."
+        },
+        {
+            "contains_type": [],
+            "data_path": "never_equate_ml_to_signature",
+            "description": "Always 'true'. ML confidence is not a signature true positive."
+        }
+    ],
+    "outputs_type": "item",
+    "platform_version": "8.6.0.0",
+    "python_version": "3.13"
+}

--- a/custom_functions/dual_signal_containment_gate.py
+++ b/custom_functions/dual_signal_containment_gate.py
@@ -1,0 +1,179 @@
+def dual_signal_containment_gate(context=None, generator_id=None, classification=None, eve_threat_confidence=None, **kwargs):
+    """
+    Gate/Prove containment: decide whether auto-contain (block ip) is allowed.
+
+    Machine-learning confidence is not a classic signature true positive.
+    SnortML GID 411, is_ml_only, and EVE-high without a classic signature must
+    not auto-contain. Signature-high and signature+ML corroboration may contain
+    (callers can still add HITL). Unknown context fails closed.
+
+    Args:
+        context (CEF type: *): Incident/notable title, description, and related text.
+        generator_id: Snort / Cisco Secure Firewall GeneratorID (411 = SnortML).
+        classification: Classic Snort classification (e.g. attempted-admin).
+        eve_threat_confidence: Encrypted Visibility Engine threat confidence 0-100.
+
+    Returns a JSON-serializable object that implements the configured data paths:
+        disposition: One of 'ml_only', 'signature', 'corroborated', or 'unknown'.
+        allow_auto_contain: 'true' or 'false' for playbook filters before block ip.
+        require_hitl: 'true' or 'false'. True for ml_only and unknown.
+        reason: Why auto-contain was allowed or denied.
+        never_equate_ml_to_signature: Always 'true'.
+    """
+    ############################ Custom Code Goes Below This Line #################################
+    import json
+    import re
+    import phantom.rules as phantom
+
+    ML_MARKERS = (
+        "gid 411",
+        "gid:411",
+        "gid=411",
+        "generator id 411",
+        "generatorid=411",
+        "generatorid:411",
+        "snortml",
+        "snort ml",
+        "is_ml_only",
+        "ml-only",
+        "ml_only",
+        "dual-signal:ml-only",
+        "dual_signal:ml_only",
+    )
+    CORR_MARKERS = (
+        "is_corroborated",
+        "dual-signal:corroborated",
+        "dual_signal:corroborated",
+        "signature and ml",
+        "signature + ml",
+        "signature plus eve",
+        "signature plus ml",
+    )
+    HIGH_PRIORITY_CLASSIFICATIONS = (
+        "attempted-admin",
+        "attempted-user",
+        "successful-admin",
+        "successful-user",
+        "shellcode-detect",
+        "trojan-activity",
+        "web-application-attack",
+        "policy-violation",
+        "misc-attack",
+        "denial-of-service",
+        "attempted-dos",
+        "successful-dos",
+        "successful-recon-largescale",
+        "successful-recon-limited",
+        "attempted-recon",
+    )
+
+    def _flatten(value):
+        if value is None:
+            return ""
+        if isinstance(value, (list, tuple)):
+            return " ".join(_flatten(item) for item in value if item is not None)
+        return str(value)
+
+    def _parse_gid(value):
+        text = _flatten(value).strip()
+        if not text:
+            return None
+        match = re.search(r"(\d+)", text)
+        if not match:
+            return None
+        try:
+            return int(match.group(1))
+        except ValueError:
+            return None
+
+    def _parse_eve(value):
+        text = _flatten(value).strip()
+        if not text:
+            return None
+        match = re.search(r"(\d+(?:\.\d+)?)", text)
+        if not match:
+            return None
+        try:
+            return float(match.group(1))
+        except ValueError:
+            return None
+
+    context_text = _flatten(context).lower()
+    classification_text = _flatten(classification).lower()
+    blob = " ".join(
+        part for part in (context_text, classification_text, _flatten(generator_id).lower()) if part
+    )
+
+    gid = _parse_gid(generator_id)
+    if gid is None:
+        gid_from_text = re.search(r"\b(?:gid|generator\s*id|generatorid)\s*[:=]?\s*(\d+)", blob)
+        if gid_from_text:
+            gid = int(gid_from_text.group(1))
+
+    eve = _parse_eve(eve_threat_confidence)
+    if eve is None:
+        eve_from_text = re.search(r"\beve(?:_threat)?(?:_confidence)?(?:pct)?\s*[:=]?\s*(\d+(?:\.\d+)?)", blob)
+        if eve_from_text:
+            eve = float(eve_from_text.group(1))
+
+    ml_from_gid = gid == 411
+    ml_from_text = any(marker in blob for marker in ML_MARKERS)
+    eve_high = eve is not None and eve >= 80
+    has_ml = ml_from_gid or ml_from_text or eve_high
+
+    # GID 411 events may still carry a class_desc; that is not a classic signature TP.
+    has_classic = (
+        (gid is not None and gid != 411)
+        or (gid != 411 and any(item in classification_text for item in HIGH_PRIORITY_CLASSIFICATIONS))
+        or bool(
+            re.search(r"\b(?:classic signature|ids signature)\b", blob)
+            or re.search(r"\b(?:gid|generator\s*id|generatorid)\s*[:=]?\s*1\b", blob)
+        )
+    )
+
+    is_corr = any(marker in blob for marker in CORR_MARKERS) or (has_ml and has_classic)
+
+    if is_corr:
+        disposition = "corroborated"
+        allow_auto_contain = "true"
+        require_hitl = "false"
+        reason = (
+            "Dual-signal corroboration (classic signature and ML/EVE). "
+            "Auto-contain is allowed; HITL remains optional."
+        )
+    elif has_ml and not has_classic:
+        disposition = "ml_only"
+        allow_auto_contain = "false"
+        require_hitl = "true"
+        reason = (
+            "ML-only path (SnortML GID 411, is_ml_only, and/or EVE-high without a classic signature). "
+            "Do not equate ML confidence to a signature true positive. Deny auto-contain; escalate / HITL."
+        )
+    elif has_classic:
+        disposition = "signature"
+        allow_auto_contain = "true"
+        require_hitl = "false"
+        reason = (
+            "Classic signature / high-priority classification without an ML-only path. "
+            "Auto-contain is allowed."
+        )
+    else:
+        disposition = "unknown"
+        allow_auto_contain = "false"
+        require_hitl = "true"
+        reason = (
+            "Insufficient dual-signal context to justify auto-contain. Fail closed; require HITL."
+        )
+
+    outputs = {
+        "disposition": disposition,
+        "allow_auto_contain": allow_auto_contain,
+        "require_hitl": require_hitl,
+        "reason": reason,
+        "never_equate_ml_to_signature": "true",
+    }
+
+    phantom.debug("dual_signal_containment_gate: {}".format(outputs))
+
+    assert json.dumps(outputs)
+    return outputs


### PR DESCRIPTION
## Summary

Adds a reusable community custom function so Splunk SOAR playbooks can **deny auto-contain** when an event is ML-only.

Community `block ip` / `risk_notable_block_indicators` paths currently flatten SnortML probability into a signature true positive. False containment is an outage and a change ticket.

**Hard rule:** ML confidence ≠ signature true positive.

This follows the same contribution shape as `ip_classify` (#238) and `generate_password` (#237): a Python 3.13 / platform 8.6 custom function, not a fork of every historical `block_indicators` branch.

## Behavior

Call `community/dual_signal_containment_gate` with notable/container text plus optional `generator_id`, `classification`, and `eve_threat_confidence`. Filter **before** `block ip`:

| `disposition` | `allow_auto_contain` | When |
|---|---|---|
| `ml_only` | `false` | SnortML GID **411**, `is_ml_only`, or EVE ≥ 80 without a classic signature |
| `signature` | `true` | Classic GID / high-priority classification |
| `corroborated` | `true` | Classic signature **and** ML/EVE |
| `unknown` | `false` | Fail closed; require HITL |

GID 411 plus a leftover `class_desc` is still **ML-only** (that field is not a classic signature TP).

Filter example: `allow_auto_contain == "false"` → prompt or stop; do not launch `block ip`.

## Wiring

Intended consumers (no edits in this PR):

- `risk_notable_block_indicators` and tagged `block, risk_notable` child playbooks
- PAN / FMC / Umbrella `block ip` actions on Cisco Secure Firewall notables

Pass `container.name` + `container.description` (and CEF GeneratorID / classification / EVE when present).

## Compounds

- ESCU dual-signal detections: https://github.com/splunk/security_content/issues/4220 · https://github.com/splunk/security_content/pull/4221
- Sentinel BlockIP Gate/Prove: https://github.com/Azure/Azure-Sentinel/pull/14926
- EvidenceForge: https://github.com/Cisco-Talos/EvidenceForge/pull/389

Optional production Gate/Prove consumer (paid Continuous Trust, not unpaid R&D): https://github.com/AAH20/aegis-decision-fabric · https://a2zsoc.com/consultation

## Test plan

- [x] Local cases: GID 411 / `is_ml_only` / EVE 92 → `ml_only` + deny
- [x] GID 1 + `attempted-admin` → `signature` + allow
- [x] GID 1 + EVE 88 → `corroborated` + allow
- [x] GID 411 + `attempted-admin` class_desc → still `ml_only`
- [x] Empty context → `unknown` + deny
- [x] Pylint E,F (`--disable=W,C,R,I,E0401`) 10/10
- [ ] CI AutomationCodeScanner on `custom_functions/*.py`
- [ ] Maintainer: call from a test container before `block ip` on a SnortML notable

Made with [Cursor](https://cursor.com)